### PR TITLE
build: Add initial 'pyproject.toml' file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >= 3.4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "heatpumps"
 description = "Collection of TESPy heat pump models and additional Streamlit dashboard."
-version="1.3.0"
+version = "1.3.0"
 readme = "README.md"
-license = "MIT"
+license = { file = "LICENSE" }
 requires-python = ">=3.9"
 authors = [
     { name = "Jonas Freißmann", email = "jonas.freissmann@web.de" },
-    { name = "Malte Fritz" },
+    { name = "Malte Fritz" }
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "coolprop>=6.4.1",
     "darkdetect>=0.8.0",
-    "fluprodia>=3.3",
+    "fluprodia==3.3",
     "matplotlib>=3.6.3",
     "numpy>=1.24.0",
     "pandas>=1.5.3",
@@ -27,7 +27,7 @@ dependencies = [
     "scikit-learn>=1.2.1",
     "scipy>=1.10.0",
     "streamlit>=1.32.0",
-    "tespy>=0.7.5",
+    "tespy>=0.7.5"
 ]
 
 [project.scripts]
@@ -36,7 +36,10 @@ heatpumps-dashboard = "heatpumps.run_dashboard:main"
 [project.urls]
 Homepage = "https://github.com/jfreissmann/heatpumps"
 
-[tool.hatch.build.targets.sdist]
+[tool.flit.sdist]
 include = [
-    "/src",
+    'static/*',
+    'static/img/*',
+    'static/img/topologies/*',
+    'models/input/*'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "heatpumps"
+description = "Collection of TESPy heat pump models and additional Streamlit dashboard."
+version="1.3.0"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.9"
+authors = [
+    { name = "Jonas Freißmann", email = "jonas.freissmann@web.de" },
+    { name = "Malte Fritz" },
+]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
+dependencies = [
+    "coolprop>=6.4.1",
+    "darkdetect>=0.8.0",
+    "fluprodia>=3.3",
+    "matplotlib>=3.6.3",
+    "numpy>=1.24.0",
+    "pandas>=1.5.3",
+    "plotly>=5.20.0",
+    "scikit-learn>=1.2.1",
+    "scipy>=1.10.0",
+    "streamlit>=1.32.0",
+    "tespy>=0.7.5",
+]
+
+[project.scripts]
+heatpumps-dashboard = "heatpumps.run_dashboard:main"
+
+[project.urls]
+Homepage = "https://github.com/jfreissmann/heatpumps"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+]


### PR DESCRIPTION
Add `pyproject.toml` declarative configuration file that fix #36.
I tried to keep all the main functionalities such as the entry point.

To execute I tested the configuration using [`uv`](https://github.com/astral-sh/uv), with:

```bash
❯ uv run heatpumps-dashboard
```
