### PR TITLE
Add tespy and heatpumps model export

### DIFF
--- a/src/heatpumps/hp_dashboard.py
+++ b/src/heatpumps/hp_dashboard.py
@@ -1253,6 +1253,29 @@ if mode == txt('mode_option_design'):
 
                     st.write(txt('design_exergy_info'))
 
+                st.divider() 
+
+                debug_json = json.dumps(
+                    {'model_key': hp_model_name, 'params': params}, indent=2
+                )
+                col1, col2 = st.columns([1,1])
+                with col1:
+                    st.download_button(
+                        label=txt('export_hp'),
+                        data=debug_json,
+                        file_name=f"{params['setup']['type']}_heatpumps.json",
+                        mime='application/json'
+                    )
+                with col2:
+                    st.download_button(
+                        label=txt('export_tespy'),
+                        data=json.dumps(ss.hp.nw.export(), indent=2),
+                        file_name=f"{params['setup']['type']}_tespy.json",
+                        mime='application/json'
+                    )
+                
+                st.divider() 
+
                 st.info(txt('design_to_od_info'))
 
                 st.button(txt('sb_btn_run_offdesign'), on_click=switch2partload)

--- a/src/heatpumps/static/translations.json
+++ b/src/heatpumps/static/translations.json
@@ -1101,5 +1101,13 @@
     "fallback_lang": {
         "ENG": "For this key no translation was found for 'English' language.",
         "GER": "Für diesen Key wurde keine Übersetzung auf 'Deutsch' gefunden."
+    },
+    "export_hp":{
+        "ENG":"Download heatpumps model as JSON",
+        "GER":"Heatpumps Modell als JSON Herunterladen"
+    },
+    "export_tespy":{
+        "ENG":"Download TesPy model as JSON",
+        "GER":"TesPy Modell als JSON Herunterladen"
     }
 }

--- a/src/heatpumps/static/translations.json
+++ b/src/heatpumps/static/translations.json
@@ -1107,7 +1107,7 @@
         "GER":"Heatpumps Modell als JSON Herunterladen"
     },
     "export_tespy":{
-        "ENG":"Download TesPy model as JSON",
-        "GER":"TesPy Modell als JSON Herunterladen"
+        "ENG":"Download TESPy model as JSON",
+        "GER":"TESPy Modell als JSON Herunterladen"
     }
 }


### PR DESCRIPTION
Add buttons in streamlit dashboard to export the model as disscussed in #53 as [tespy json file](https://tespy.readthedocs.io/en/main/api/tespy.networks.html#tespy.networks.network.Network.export) or heatpumps json configuration file as implemented in PR #50.

Curretly #50 allows only an export when simulation fails, thats why I added the button in the regular result field. This could also be moved to #50 if preferred. 